### PR TITLE
Added support for `msgid_plural`

### DIFF
--- a/src/Catalog/EntryFactory.php
+++ b/src/Catalog/EntryFactory.php
@@ -18,6 +18,10 @@ class EntryFactory
 
         foreach ($entryArray as $key => $value) {
             switch (true) {
+                case $key === 'msgid_plural':
+                    $entry->setMsgIdPlural($entryArray['msgid_plural']);
+                    break;
+                    
                 case $key === 'msgctxt':
                     $entry->setMsgCtxt($entryArray['msgctxt']);
                     break;


### PR DESCRIPTION
With following file the `msgid_plural` is set to null, this patch fixes this.

```
msgid "%d window"
msgid_plural "%d windows"
msgstr[0] ""
msgstr[1] ""
```