### PR TITLE
Fix PHPDoc types for nullable `Entry` properties

### DIFF
--- a/src/Catalog/Entry.php
+++ b/src/Catalog/Entry.php
@@ -65,7 +65,7 @@ class Entry
     }
 
     /**
-     * @param string $msgStr
+     * @param string|null $msgStr
      *
      * @return Entry
      */
@@ -77,7 +77,7 @@ class Entry
     }
 
     /**
-     * @param string $msgIdPlural
+     * @param string|null $msgIdPlural
      *
      * @return Entry
      */
@@ -89,7 +89,7 @@ class Entry
     }
 
     /**
-     * @param string $msgCtxt
+     * @param string|null $msgCtxt
      *
      * @return Entry
      */
@@ -113,7 +113,7 @@ class Entry
     }
 
     /**
-     * @param bool $obsolete
+     * @param bool|null $obsolete
      *
      * @return Entry
      */


### PR DESCRIPTION
Since these properties are all nullable (e.g. [`$msgStr`](https://github.com/pherrymason/PHP-po-parser/blob/6.0.2/src/Catalog/Entry.php#L10)) and the other property, that is also nullable - [`$previousEntry` has null allowed in setter](https://github.com/pherrymason/PHP-po-parser/blob/6.0.2/src/Catalog/Entry.php#L104) I think the missing null types in setters are rather oversight than intention. Also there is probably not really a reason to not allow null if the property can already be nullable from instantiation.